### PR TITLE
Fix word-count regex in modality mismatch warning

### DIFF
--- a/src/gabriel/utils/modality_utils.py
+++ b/src/gabriel/utils/modality_utils.py
@@ -44,7 +44,7 @@ def warn_if_modality_mismatch(
             audio_hits += 1
             continue
         if isinstance(candidate, str):
-            words = re.findall(r"\\b\\w+\\b", candidate)
+            words = re.findall(r"\b\w+\b", candidate)
             text_word_counts.append(len(words))
 
     total = len(sample)


### PR DESCRIPTION
### Motivation
- The average word-count check in `warn_if_modality_mismatch` was reporting incorrect counts (e.g. 0.0) because the word regex was double-escaped and therefore not matching actual words.

### Description
- Replace `re.findall(r"\\b\\w+\\b", candidate)` with `re.findall(r"\b\w+\b", candidate)` in `src/gabriel/utils/modality_utils.py` so text inputs are measured correctly.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_6985114676e0832ead9e015ffca3e4c5)