### PR TITLE
Fix classify aggregation warning and log audio encoding failures

### DIFF
--- a/src/gabriel/tasks/classify.py
+++ b/src/gabriel/tasks/classify.py
@@ -507,9 +507,10 @@ class Classify:
 
         # aggregate across runs using a minimum frequency threshold
         def _min_freq(s: pd.Series) -> Optional[bool]:
-            if s.notna().sum() == 0:
+            s_bool = s.astype("boolean")
+            if s_bool.notna().sum() == 0:
                 return None
-            true_count = s.fillna(False).infer_objects(copy=False).sum()
+            true_count = int(s_bool.sum(skipna=True))
             prop = true_count / self.cfg.n_runs
             return prop >= self.cfg.min_frequency
 

--- a/src/gabriel/utils/audio_utils.py
+++ b/src/gabriel/utils/audio_utils.py
@@ -6,6 +6,9 @@ import base64
 from pathlib import Path
 from typing import Dict, Optional
 
+from .logging import get_logger
+
+logger = get_logger(__name__)
 
 def encode_audio(audio_path: str) -> Optional[Dict[str, str]]:
     """Return the audio at ``audio_path`` as a dict suitable for the OpenAI API.
@@ -37,6 +40,6 @@ def encode_audio(audio_path: str) -> Optional[Dict[str, str]]:
             b64 = base64.b64encode(f.read()).decode("utf-8")
         ext = path.suffix.lstrip(".").lower() or "wav"
         return {"data": b64, "format": ext}
-    except Exception:
+    except Exception as exc:
+        logger.warning("Failed to encode audio file %s: %s", audio_path, exc)
         return None
-

--- a/src/gabriel/utils/media_utils.py
+++ b/src/gabriel/utils/media_utils.py
@@ -6,6 +6,9 @@ from typing import Any, Dict, List
 from .image_utils import encode_image
 from .audio_utils import encode_audio
 from .pdf_utils import encode_pdf
+from .logging import get_logger
+
+logger = get_logger(__name__)
 
 
 def load_image_inputs(val: Any) -> List[str]:
@@ -43,6 +46,13 @@ def load_audio_inputs(val: Any) -> List[Dict[str, str]]:
             enc = encode_audio(aud)
             if enc:
                 encoded.append(enc)
+            else:
+                logger.warning(
+                    "Audio encoding failed for %s; the file may be corrupted or unreadable.",
+                    aud,
+                )
+        elif isinstance(aud, str) and not os.path.exists(aud):
+            logger.warning("Audio path not found: %s", aud)
         elif isinstance(aud, dict):
             encoded.append(aud)
     return encoded


### PR DESCRIPTION
### Motivation
- Suppress a pandas FutureWarning caused by downcasting when aggregating nullable boolean series in the classification post-processing.
- Surface and log audio encoding / missing-file failures that can produce repeated NaNs in audio tests so the root cause (corrupted vs missing files vs pipeline) is easier to diagnose.

### Description
- Rewrote the aggregation helper `_min_freq` in `src/gabriel/tasks/classify.py` to coerce series to a nullable boolean via `s.astype("boolean")` and compute `true_count = int(s_bool.sum(skipna=True))` instead of using `s.fillna(False).infer_objects(copy=False).sum()`.
- Added module logging to `src/gabriel/utils/audio_utils.py` and log a warning in `encode_audio` when a file fails to be read/encoded.
- Added a logger to `src/gabriel/utils/media_utils.py` and emit warnings when `encode_audio` returns `None` (indicating a corrupt/unreadable file) and when an audio file path does not exist.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_698594c59d28832eab225917af387f0b)