### PR TITLE
Forward custom response_fn/get_all_responses_fn through extract wrapper and add tests

### DIFF
--- a/src/gabriel/api.py
+++ b/src/gabriel/api.py
@@ -289,6 +289,8 @@ async def extract(
         column_name,
         reset_files=reset_files,
         types=types,
+        response_fn=response_fn,
+        get_all_responses_fn=get_all_responses_fn,
     )
 
 


### PR DESCRIPTION
### Motivation
- Fix a wiring bug where the `response_fn` and `get_all_responses_fn` arguments passed to the top-level `extract` API wrapper were not being forwarded to the underlying task execution, preventing custom response handlers from taking effect.

### Description
- Forward `response_fn` and `get_all_responses_fn` through the `extract` wrapper into `Extract.run` by passing them in the call in `src/gabriel/api.py`.
- Add `test_extract_custom_response_functions` to `tests/test_basic.py` to exercise both a per-prompt `response_fn` and a full-driver `get_all_responses_fn`, asserting the received prompts/identifiers and the parsed extraction output.
- Changes touch `src/gabriel/api.py` and `tests/test_basic.py` and keep existing behavior unchanged when custom callables are not supplied.

### Testing
- Ran `pytest tests/test_basic.py::test_extract_custom_response_functions`, which passed (1 test, 1 passed).
- The new test verifies that a custom per-prompt `response_fn` receives the rendered prompt and that a custom `get_all_responses_fn` receives the batched `prompts`/`identifiers` and that extraction results are parsed as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_6985dbfade78832e9a33d8fc8ee9aa4c)