### PR TITLE
Propagate response_fn / get_all_responses_fn through Discover pipeline

### DIFF
--- a/src/gabriel/tasks/discover.py
+++ b/src/gabriel/tasks/discover.py
@@ -211,6 +211,7 @@ class Discover:
                 categories=None,
                 additional_instructions=self.cfg.additional_instructions or "",
                 reset_files=reset_files,
+                **kwargs,
             )
             term_defs: Dict[str, str] = {}
             if "coded_passages" in codify_df:
@@ -249,6 +250,7 @@ class Discover:
                 circle_column_name,  # type: ignore[arg-type]
                 square_column_name,  # type: ignore[arg-type]
                 reset_files=reset_files,
+                **kwargs,
             )
             term_defs = {}
             for attr, expl in zip(
@@ -293,6 +295,7 @@ class Discover:
                 candidate_df,
                 "term",
                 reset_files=reset_files,
+                **kwargs,
             )
 
         labels = (
@@ -390,6 +393,7 @@ class Discover:
                 circle_column_name=circle_column_name,  # type: ignore[arg-type]
                 square_column_name=square_column_name,  # type: ignore[arg-type]
                 reset_files=reset_files,
+                **kwargs,
             )
 
             actual_combined_labels = dict(clf.cfg.labels)
@@ -489,6 +493,7 @@ class Discover:
                 df,
                 column_name,  # type: ignore[arg-type]
                 reset_files=reset_files,
+                **kwargs,
             )
             actual_labels = dict(clf.cfg.labels)
             if actual_labels != labels:


### PR DESCRIPTION
### Motivation
- Ensure custom per-prompt or driver overrides (`response_fn` / `get_all_responses_fn` and other runtime kwargs) passed into `Discover.run` actually reach the downstream stages (Codify, Compare, Bucket, Classify) so custom handlers are honored end-to-end. 
- Note: the core helper `get_all_responses` already implements precedence, validation and behavior for custom drivers and response functions, so the pipeline should forward the kwargs rather than swallow them.

### Description
- Forward `**kwargs` from `Discover.run` into internal stage calls by adding `**kwargs` when calling `coder.run`, `cmp.run`, `buck.run`, `clf.run` in `src/gabriel/tasks/discover.py` so options such as `response_fn` and `get_all_responses_fn` are propagated. 
- No change to `get_all_responses` itself; it continues to validate custom drivers (requires `prompts`/`identifiers`) and to make `get_all_responses_fn` take precedence over `response_fn` when both are supplied.
- Small, targeted change confined to `src/gabriel/tasks/discover.py` to unblock end-to-end custom response overrides.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_6985e01473b8832e9a8c7a32e9b88e24)