### PR TITLE
Refine paraphrase prompt; forward media modalities and support JSON mode

### DIFF
--- a/src/gabriel/api.py
+++ b/src/gabriel/api.py
@@ -1133,6 +1133,8 @@ async def paraphrase(
     reset_files: bool = False,
     reasoning_effort: Optional[str] = None,
     reasoning_summary: Optional[str] = None,
+    modality: str = "text",
+    search_context_size: str = "medium",
     n_rounds: int = 1,
     recursive_validation: Optional[bool] = None,
     n_initial_candidates: int = 1,
@@ -1171,6 +1173,10 @@ async def paraphrase(
         Whether to request JSON responses.
     web_search:
         Enable web search augmentation when supported by the model.
+    modality:
+        Modality of inputs (text, image, audio, pdf, entity, web).
+    search_context_size:
+        Web search context size when ``modality="web"``.
     n_parallels:
         Maximum concurrent paraphrase calls.
     use_dummy:
@@ -1220,6 +1226,8 @@ async def paraphrase(
         use_dummy=use_dummy,
         reasoning_effort=reasoning_effort,
         reasoning_summary=reasoning_summary,
+        modality=modality,
+        search_context_size=search_context_size,
         n_rounds=n_rounds,
         recursive_validation=recursive_validation,
         n_initial_candidates=n_initial_candidates,

--- a/src/gabriel/prompts/paraphrase_prompt.jinja2
+++ b/src/gabriel/prompts/paraphrase_prompt.jinja2
@@ -1,17 +1,24 @@
-Consider the following text:
-BEGIN TEXT
-{{ text }}
-END TEXT
-Your task is to rewrite the above text in accordance with the following instructions:
+{% import "snippets.jinja2" as snip %}
+{{ snip.single_entry(modality, text) }}
+
+Task: rewrite the provided content according to the instructions below. Be diligent, thorough, and faithful to the instructions in all cases.
+
 BEGIN INSTRUCTIONS
 {{ instructions }}
 END INSTRUCTIONS
-The text should be rewritten in a way that is consistent with the instructions.
-Be very diligent about following the instructions.
-Output only your revised text, nothing else, no preamble, no postamble, no explanation, no nothing other than the revised text.
-Consider the whole text, and follow the instructions carefully and completely.
-Be meticulous and exacting; your output of rewritten text must be as faithful as possible in following the instructions.
-Once again, the instructions are:
-BEGIN INSTRUCTIONS
-{{ instructions }}
-END INSTRUCTIONS
+
+Modality guidance:
+- text: paraphrase the full passage, preserving meaning and key details while applying the instructions.
+- entity: rewrite the entity name in a consistent way per the instructions.
+- web: paraphrase/consolidate the web content found for the search term per the instructions.
+- image/audio/pdf: paraphrase the observed content into text in accordance with the instructions.
+
+Output format (template):
+{% if json_mode %}
+Always output JSON only in the indicated format.
+{"revised_text": "<revised_text>"}
+{% else %}
+<revised_text>
+{% endif %}
+
+No preamble, no explanation, only the desired revised text alone, faithful to the provided content and in accordance with the instructions.


### PR DESCRIPTION
### Motivation
- Improve paraphrase prompt clarity and fidelity to instructions while removing example blocks that confused guidance.
- Support multimodal paraphrasing by forwarding image/audio/pdf attachments and clarifying behavior per modality.
- Ensure callers can request JSON-only outputs when `json_mode` is enabled and surface modality/search settings through the API.

### Description
- Tighten and rework `src/gabriel/prompts/paraphrase_prompt.jinja2` to remove examples, emphasize instruction fidelity, add concise modality guidance, and conditionally require JSON-only output when `json_mode` is set, with the final output wording changed to the requested phrasing.
- Pass `json_mode` into prompt rendering and propagate modality/search options from the API by updating `src/gabriel/tasks/paraphrase.py` to forward `prompt_images`, `prompt_audio`, and `prompt_pdfs` to the underlying helper, call `warn_if_modality_mismatch`, and use `load_image_inputs`/`load_audio_inputs`/`load_pdf_inputs` when appropriate.
- Expose `modality` and `search_context_size` on the `paraphrase` API in `src/gabriel/api.py` and wire defaults so `web_search` and `search_context_size` behave sensibly when `modality == "web"`.
- Update recursive generation to accept original values for media forwarding and pass `search_context_size` into `get_all_responses`.
- Update tests in `tests/test_basic.py` to add `test_paraphrase_modalities_forward_media` and adapt existing paraphrase tests to the new signatures and behavior.

### Testing
- Added unit test `test_paraphrase_modalities_forward_media` and updated existing paraphrase tests in `tests/test_basic.py` to reflect the new API and media-forwarding behavior.
- No automated test suite was executed as part of this rollout (prompt/template and code changes were prepared and committed but not run under `pytest`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_69866034e67c832e892016c6776e68b8)