### PR TITLE
Collapse ideate dedup output to unique representative rows

### DIFF
--- a/src/gabriel/tasks/ideate.py
+++ b/src/gabriel/tasks/ideate.py
@@ -501,8 +501,24 @@ class Ideate:
             reset_files=reset_files,
             **dedup_run_opts,
         )
-        if "mapped_report_text" in dedup_df.columns:
-            dedup_df["report_text"] = dedup_df["mapped_report_text"]
+        mapped_col = "mapped_report_text"
+        mapped_id_col = "mapped_report_text_ids"
+        if mapped_col in dedup_df.columns:
+            dedup_df["report_text"] = dedup_df[mapped_col]
+        if mapped_id_col in dedup_df.columns and "_dedup_id" in dedup_df.columns:
+            rep_mask = dedup_df["_dedup_id"] == dedup_df[mapped_id_col]
+            rep_mask |= dedup_df["_dedup_id"].isna() & dedup_df[mapped_id_col].isna()
+            dedup_df = dedup_df.loc[rep_mask].copy()
+            print(
+                "[Ideate] Collapsed to "
+                f"{len(dedup_df)} representative rows after deduplication."
+            )
+        elif mapped_col in dedup_df.columns:
+            dedup_df = dedup_df.drop_duplicates(subset=[mapped_col]).copy()
+            print(
+                "[Ideate] Collapsed to "
+                f"{len(dedup_df)} representative rows after deduplication."
+            )
         return dedup_df
 
     def _clean_columns(self, df: pd.DataFrame) -> pd.DataFrame:


### PR DESCRIPTION
### Motivation
- The ideate pipeline was leaving one row per original generated idea even after deduplication, causing duplicate analyses to persist and downstream ranking to operate on duplicate entries.
- After mapping duplicates to a representative idea, the DataFrame should be consolidated to only the representative rows so scoring and ranking run over unique ideas.

### Description
- Map `report_text` to the LLM-provided representative text when `mapped_report_text` is present by assigning `dedup_df["report_text"] = dedup_df["mapped_report_text"]`.
- When both `mapped_report_text_ids` and `_dedup_id` exist, keep only rows where `_dedup_id == mapped_report_text_ids` (or both are `NaN`) to collapse to representative rows, and log the resulting row count using `print`.
- If only `mapped_report_text` is present, drop duplicate rows using `drop_duplicates(subset=["mapped_report_text"])` and log the collapsed row count.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_69869508bbf4832eb4bb520fed3f82e3)