### PR TITLE
Fix background mode auto-enable for long requests

### DIFF
--- a/src/gabriel/utils/openai_utils.py
+++ b/src/gabriel/utils/openai_utils.py
@@ -1779,7 +1779,7 @@ async def get_response(
     elif background_mode is not None:
         effective_background = bool(background_mode)
     else:
-        effective_background = False
+        effective_background = timeout is None
     background_argument: Optional[bool] = None
     if explicit_background is not None:
         background_argument = bool(explicit_background)


### PR DESCRIPTION
### Motivation
- Ensure `get_response` auto-enables background polling for long-running requests when no `timeout` is provided, matching the documented behavior instead of defaulting to `False`.

### Description
- Update in `src/gabriel/utils/openai_utils.py` where `effective_background` is now set to `timeout is None` rather than `False`, so background mode is automatically used when callers omit a `timeout`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_6986c9d7bd70832ebabba8c29846a62d)