### PR TITLE
Silence tracebacks for rate limit and connection errors in get_response

### DIFF
--- a/src/gabriel/utils/openai_utils.py
+++ b/src/gabriel/utils/openai_utils.py
@@ -1961,6 +1961,9 @@ async def get_response(
             )
             logger.error(f"[get_response] {message}")
             raise asyncio.TimeoutError(message) from exc
+        except (RateLimitError, APIConnectionError) as e:
+            logger.debug("[get_response] API call resulted in exception: %r", e)
+            raise
         except Exception as e:
             logger.error(
                 "[get_response] API call resulted in exception: %r", e, exc_info=True
@@ -2070,6 +2073,9 @@ async def get_response(
             )
             logger.error(f"[get_response] {message}")
             raise asyncio.TimeoutError(message) from exc
+        except (RateLimitError, APIConnectionError) as e:
+            logger.debug("[get_response] API call resulted in exception: %r", e)
+            raise
         except Exception as e:
             logger.error(
                 "[get_response] API call resulted in exception: %r", e, exc_info=True


### PR DESCRIPTION
### Motivation
- Reduce noisy full-traceback logging for recoverable `RateLimitError` and `APIConnectionError` so the first-occurrence notices handle user-visible output and subsequent occurrences are silenced and tracked in periodic status updates.

### Description
- In `src/gabriel/utils/openai_utils.py` updated both API-call branches in `get_response` to catch `RateLimitError` and `APIConnectionError` and log them at `DEBUG` (no `exc_info`) before re-raising, instead of logging full error tracebacks at `ERROR`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_6986ebd39278832eb37dc6b6701081e8)