### PR TITLE
Fix parallel recovery cap resets and reduce duplicate warnings

### DIFF
--- a/src/gabriel/utils/openai_utils.py
+++ b/src/gabriel/utils/openai_utils.py
@@ -4481,9 +4481,10 @@ async def get_all_responses(
             msg = (
                 "Encountered first rate limit error. Future rate limit errors will be silenced and tracked in periodic updates."
             )
-            logger.warning(msg)
             if message_verbose:
                 print(msg)
+            else:
+                logger.warning(msg)
             first_rate_limit_logged = True
         else:
             if detail:
@@ -4497,9 +4498,10 @@ async def get_all_responses(
             msg = (
                 "Encountered first connection error. Future connection errors will be silenced and tracked in periodic updates."
             )
-            logger.warning(msg)
             if message_verbose:
                 print(msg)
+            else:
+                logger.warning(msg)
             first_connection_logged = True
         else:
             if detail:
@@ -4518,9 +4520,10 @@ async def get_all_responses(
         if concurrency_cap > ramp_cap:
             concurrency_cap = ramp_cap
         msg = f"[parallelization] Halting ramp-up at {ramp_cap} due to {reason}."
-        logger.warning(msg)
         if message_verbose:
             print(msg)
+        else:
+            logger.warning(msg)
 
     def _record_timeout_event(now: Optional[float] = None) -> None:
         ts = now if now is not None else time.time()
@@ -4961,7 +4964,6 @@ async def get_all_responses(
                     f"{int(round(error_window))}s (rate-limit={recent_rate_limit_errors}, "
                     f"connection={recent_connection_errors})."
                 )
-                logger.warning(reason)
                 _halt_ramp_up("error recovery")
                 emit_parallelization_status(reason, force=True)
             rate_limit_errors_since_adjust = 0
@@ -4986,7 +4988,7 @@ async def get_all_responses(
             and (now - last_concurrency_scale_up) >= error_window
         ):
             growth_headroom_limit = max(1, int(math.floor(ceiling_cap * 0.9)))
-            success_threshold = max(60, int(math.ceil(concurrency_cap * 2.5)))
+            success_threshold = max(60, int(math.ceil(concurrency_cap * 1.5)))
             if (
                 concurrency_cap < growth_headroom_limit
                 and successes_since_adjust >= success_threshold
@@ -5427,7 +5429,6 @@ async def get_all_responses(
                         dedup_key=("cap-adjustment", type(e).__name__, str(e)),
                     )
                     logger.debug("Throughput tuning failed; retaining existing cap.", exc_info=True)
-                concurrency_cap = new_cap
                 if resps and all((isinstance(r, str) and not r.strip()) for r in resps):
                     if call_timeout is not None:
                         elapsed = time.time() - start


### PR DESCRIPTION
### Motivation
- Prevent unintended resets of the worker concurrency cap after error-driven reductions so the system does not jump back to the requested maximum unexpectedly. 
- Avoid duplicate output when logging the first rate-limit/connection errors so only a single message is emitted by default. 
- Make ramping concurrency back up less conservative by lowering the sustained-success threshold so recovery is faster once stability is observed. 

### Description
- Updated first-error logging in `get_all_responses` so `_log_rate_limit_once` and `_log_connection_once` only call `logger.warning` when `message_verbose` is false, avoiding duplicate prints and warnings. 
- Changed `_halt_ramp_up` to print when `message_verbose` is enabled and otherwise issue a single `logger.warning`, removing duplicate messaging. 
- Prevented throughput tuning from overwriting a previously reduced `concurrency_cap` by removing the unintended assignment that reset the cap during dynamic tuning. 
- Lowered the sustained-success threshold multiplier used to grow concurrency from `2.5x` to `1.5x` of the current cap to speed recovery after stable periods. 
- All changes are in `src/gabriel/utils/openai_utils.py` and focus on parallel recovery/logging behavior. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_69870a30e5b0832e9e99e16edb7b952f)