### PR TITLE
Reduce parallel recovery growth increment to 0.1

### DIFF
--- a/src/gabriel/utils/openai_utils.py
+++ b/src/gabriel/utils/openai_utils.py
@@ -4994,7 +4994,7 @@ async def get_all_responses(
                 concurrency_cap < growth_headroom_limit
                 and successes_since_adjust >= success_threshold
             ):
-                increment = max(1, int(math.ceil(max(concurrency_cap * 0.15, 2))))
+                increment = max(1, int(math.ceil(max(concurrency_cap * 0.1, 2))))
                 new_cap = min(ceiling_cap, concurrency_cap + increment)
                 if new_cap != concurrency_cap:
                     old_cap = concurrency_cap


### PR DESCRIPTION
### Motivation
- Reduce how aggressively the concurrency cap ramps up after sustained success to make parallel recovery more conservative and avoid overshooting during transient recovery.

### Description
- Change the parallel recovery increment multiplier from `0.15` to `0.1` in `src/gabriel/utils/openai_utils.py` so `increment = max(1, int(math.ceil(max(concurrency_cap * 0.1, 2))))`; also verified that rate-limit and connection errors use the existing retry/backoff behavior via `_handle_rate_limit_error` and the `APIConnectionError` branch which enqueue retries through `_maybe_retry` when attempts remain.

### Testing
- No automated tests were executed for this change (no test run requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_69871049b9bc832ebe00f016c43cb951)