### PR TITLE
Tune HTTPX connection limits and default ramp-up time

### DIFF
--- a/src/gabriel/utils/openai_utils.py
+++ b/src/gabriel/utils/openai_utils.py
@@ -121,7 +121,7 @@ except Exception:
 from gabriel.utils.parsing import parse_json_with_status, safe_json
 
 # single connection pool per process, keyed by base URL and created lazily
-_clients_async: Dict[Optional[str], openai.AsyncOpenAI] = {}
+_clients_async: Dict[Tuple[Optional[str], Optional[int], Optional[int]], openai.AsyncOpenAI] = {}
 
 
 def _progress_bar(*args: Any, verbose: bool = True, **kwargs: Any):
@@ -142,7 +142,12 @@ def _display_example_prompt(example_prompt: str, *, verbose: bool = True) -> Non
     print(textwrap.indent(example_prompt.strip("\n"), "  "))
 
 
-def _get_client(base_url: Optional[str] = None) -> openai.AsyncOpenAI:
+def _get_client(
+    base_url: Optional[str] = None,
+    *,
+    httpx_max_connections: Optional[int] = None,
+    httpx_max_keepalive_connections: Optional[int] = None,
+) -> openai.AsyncOpenAI:
     """Return a cached ``AsyncOpenAI`` client for ``base_url``.
 
     When ``base_url`` is ``None`` the default OpenAI endpoint is used.  A client
@@ -151,21 +156,28 @@ def _get_client(base_url: Optional[str] = None) -> openai.AsyncOpenAI:
     """
 
     url = base_url or os.getenv("OPENAI_BASE_URL")
-    key: Optional[str] = url
+    key = (url, httpx_max_connections, httpx_max_keepalive_connections)
     client = _clients_async.get(key)
     if client is None:
         kwargs: Dict[str, Any] = {}
         if url:
             kwargs["base_url"] = url
         if httpx is not None:
+            timeout: Optional[httpx.Timeout] = None
             try:
-                kwargs.setdefault(
-                    "timeout",
-                    httpx.Timeout(connect=10.0, read=None, write=None, pool=None),
-                )
+                timeout = httpx.Timeout(connect=10.0, read=None, write=None, pool=None)
             except Exception:
                 # Fall back to the SDK default if constructing the timeout fails
-                pass
+                timeout = None
+            if httpx_max_connections or httpx_max_keepalive_connections:
+                limits = httpx.Limits(
+                    max_connections=httpx_max_connections,
+                    max_keepalive_connections=httpx_max_keepalive_connections,
+                )
+                http_client = httpx.AsyncClient(limits=limits, timeout=timeout)
+                kwargs["http_client"] = http_client
+            elif timeout is not None:
+                kwargs.setdefault("timeout", timeout)
         client = openai.AsyncOpenAI(**kwargs)
         _clients_async[key] = client
     return client
@@ -1693,6 +1705,8 @@ async def get_response(
     logging_level: Optional[Union[str, int]] = None,
     background_mode: Optional[bool] = None,
     background_poll_interval: float = 10.0,
+    httpx_max_connections: Optional[int] = None,
+    httpx_max_keepalive_connections: Optional[int] = None,
     **kwargs: Any,
 ):
     """Request one or more model completions from the OpenAI API.
@@ -1771,6 +1785,8 @@ async def get_response(
         How frequently (in seconds) to poll for background completion when
         background mode is active. Defaults to 10 seconds and automatically
         lengthens when rate-limit responses instruct a longer pause.
+    httpx_max_connections, httpx_max_keepalive_connections:
+        Optional HTTPX connection limits to apply to the shared client.
     **kwargs:
         Any additional parameters understood by the OpenAI SDK are forwarded
         transparently.
@@ -1801,7 +1817,11 @@ async def get_response(
         set_log_level(logging_level)
     _require_api_key()
     base_url = base_url or os.getenv("OPENAI_BASE_URL")
-    client_async = _get_client(base_url)
+    client_async = _get_client(
+        base_url,
+        httpx_max_connections=httpx_max_connections,
+        httpx_max_keepalive_connections=httpx_max_keepalive_connections,
+    )
 
     try:
         poll_interval = float(background_poll_interval)
@@ -3001,8 +3021,10 @@ async def get_all_responses(
     # this ceiling to half of the requested value to avoid overwhelming
     # the API or tool backends.
     n_parallels: int = 650,
-    ramp_up_seconds: float = 15.0,
+    ramp_up_seconds: float = 25.0,
     ramp_up_start_fraction: float = 0.2,
+    httpx_max_connections: Optional[int] = None,
+    httpx_max_keepalive_connections: Optional[int] = None,
     max_retries: int = 3,
     timeout_factor: float = 2.5,
     max_timeout: Optional[float] = None,
@@ -3070,6 +3092,11 @@ async def get_all_responses(
     again so brief spikes do not trigger runaway
     throttling, while successful calls reset the counters and allow the pool to
     scale back up.
+
+    The shared HTTPX client can be tuned via ``httpx_max_connections`` and
+    ``httpx_max_keepalive_connections``.  When not supplied, the helper derives
+    a default limit from the requested ``n_parallels`` so that the connection
+    pool can accommodate the full worker ceiling.
 
     Connection errors (e.g., transient network drops, Wi‑Fi/VPN instability, or bandwidth limitations)
     are handled similarly: the helper tracks recent connection failures over
@@ -3400,6 +3427,10 @@ async def get_all_responses(
     status = StatusTracker()
     requested_n_parallels = max(1, n_parallels)
     user_requested_n_parallels = requested_n_parallels
+    if httpx_max_connections is None:
+        httpx_max_connections = int(math.ceil(requested_n_parallels * 1.5))
+    if httpx_max_keepalive_connections is None:
+        httpx_max_keepalive_connections = httpx_max_connections
     tokenizer = _get_tokenizer(model)
     # Backwards compatibility for identifiers
     if identifiers is None:
@@ -3419,6 +3450,10 @@ async def get_all_responses(
     # Pass the chosen model through to get_response by default
     get_response_kwargs.setdefault("model", model)
     get_response_kwargs.setdefault("base_url", base_url)
+    get_response_kwargs.setdefault("httpx_max_connections", httpx_max_connections)
+    get_response_kwargs.setdefault(
+        "httpx_max_keepalive_connections", httpx_max_keepalive_connections
+    )
     if background_mode is not None:
         get_response_kwargs.setdefault("background_mode", background_mode)
     get_response_kwargs.setdefault("background_poll_interval", background_poll_interval)


### PR DESCRIPTION
### Motivation
- Ensure the shared HTTPX connection pool can accommodate the initial concurrency ceiling so the pool is not underprovisioned relative to the requested `n_parallels` value. 
- Expose explicit HTTPX connection-limit knobs so callers can override derived defaults for restrictive environments. 
- Make the worker ramp-up gentler by increasing the default ramp-up time.

### Description
- Added optional `httpx_max_connections` and `httpx_max_keepalive_connections` parameters to `get_response` and `get_all_responses` and threaded them into the shared client creation. 
- Changed the shared client cache key to include the HTTPX limit parameters and create a configured `httpx.AsyncClient` with `httpx.Limits` when limits are supplied. 
- When limits are not provided the helper now derives a sensible default from the requested ceiling as `ceil(n_parallels * 1.5)` (e.g., 650 -> 975) and uses the same value for keepalive connections. 
- Increased the default `ramp_up_seconds` from 15 to 25 and added explanatory docs about the new HTTPX tuning knobs.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_69878a21b0ec832e90b5650456aec94a)