### PR TITLE
Adjust default ramp-up duration to 20s

### DIFF
--- a/src/gabriel/utils/openai_utils.py
+++ b/src/gabriel/utils/openai_utils.py
@@ -3021,7 +3021,7 @@ async def get_all_responses(
     # this ceiling to half of the requested value to avoid overwhelming
     # the API or tool backends.
     n_parallels: int = 650,
-    ramp_up_seconds: float = 25.0,
+    ramp_up_seconds: float = 20.0,
     ramp_up_start_fraction: float = 0.2,
     httpx_max_connections: Optional[int] = None,
     httpx_max_keepalive_connections: Optional[int] = None,


### PR DESCRIPTION
### Motivation
- Reduce the default ramp-up time used by the parallelization helper to shorten the period before full concurrency is reached for `get_all_responses` in `src/gabriel/utils/openai_utils.py`.

### Description
- Change the default parameter `ramp_up_seconds` from `25.0` to `20.0` in the `get_all_responses` function signature in `src/gabriel/utils/openai_utils.py`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_69878f7fa448832ebe974edb6306a9b8)