### PR TITLE
Set default ramp-up duration to 15 seconds

### DIFF
--- a/src/gabriel/utils/openai_utils.py
+++ b/src/gabriel/utils/openai_utils.py
@@ -3021,7 +3021,7 @@ async def get_all_responses(
     # this ceiling to half of the requested value to avoid overwhelming
     # the API or tool backends.
     n_parallels: int = 650,
-    ramp_up_seconds: float = 20.0,
+    ramp_up_seconds: float = 15.0,
     ramp_up_start_fraction: float = 0.2,
     httpx_max_connections: Optional[int] = None,
     httpx_max_keepalive_connections: Optional[int] = None,


### PR DESCRIPTION
### Motivation
- Shorten the initial ramp-up period for parallel request workers by reducing the default `ramp_up_seconds` value to make warm-up quicker for `get_all_responses` calls.

### Description
- Change the default `ramp_up_seconds` parameter from `20.0` to `15.0` in `src/gabriel/utils/openai_utils.py` for the `get_all_responses` function.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_6987919d0748832e90e642d8e4577fe9)