### PR TITLE
Add statsmodels to core dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ dependencies = [
     "pydantic>=1.10.0",
     "pypdf>=4.0.0",
     "python-docx>=1.1.0",
+    "statsmodels>=0.14.0",
 ]
 
 [project.optional-dependencies]
@@ -72,7 +73,6 @@ dev = [
     "mypy>=1.0.0",
 ]
 analysis = [
-    "statsmodels>=0.14.0",
     "tabulate>=0.9.0",
 ]
 notebook = [


### PR DESCRIPTION
### Motivation
- Prevent runtime `ImportError` in plotting and regression utilities by ensuring `statsmodels` is available as a core dependency.

### Description
- Update `pyproject.toml` to add `statsmodels>=0.14.0` to the main `dependencies` and remove it from the `analysis` optional extras, changing the package resolution for runtime consumers.

### Testing
- No automated tests were run for this dependency-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_698a354e6228832eb4ba52cf9fe1bb01)