### PR TITLE
Fix get_response client initialization

### DIFF
--- a/src/gabriel/utils/openai_utils.py
+++ b/src/gabriel/utils/openai_utils.py
@@ -1819,11 +1819,14 @@ async def get_response(
         set_log_level(logging_level)
     _require_api_key()
     base_url = base_url or os.getenv("OPENAI_BASE_URL")
-    client_async = _get_client(
-        base_url,
-        httpx_max_connections=httpx_max_connections,
-        httpx_max_keepalive_connections=httpx_max_keepalive_connections,
-    )
+    if httpx_max_connections or httpx_max_keepalive_connections:
+        client_async = _get_client(
+            base_url,
+            httpx_max_connections=httpx_max_connections,
+            httpx_max_keepalive_connections=httpx_max_keepalive_connections,
+        )
+    else:
+        client_async = _get_client(base_url)
 
     try:
         poll_interval = float(background_poll_interval)


### PR DESCRIPTION
### Motivation
- Prevent `TypeError` when tests or monkeypatched clients replace `_get_client` without accepting HTTPX connection keyword arguments by avoiding passing those kwargs unless explicitly set.

### Description
- Only pass `httpx_max_connections` and `httpx_max_keepalive_connections` to `_get_client` when they are truthy, otherwise call `_get_client(base_url)` to preserve compatibility; change applied in `src/gabriel/utils/openai_utils.py`.

### Testing
- Ran `pytest -q`, which completed successfully with `177 passed, 6 skipped` (with warnings).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_698a4bd83c3c832ea49de8e5fba0b0ba)