### PR TITLE
Fix bar_plot duplicate columns for excess data

### DIFF
--- a/src/gabriel/utils/plot_utils.py
+++ b/src/gabriel/utils/plot_utils.py
@@ -1897,7 +1897,7 @@ def bar_plot(
                     prefix=excess_prefix,
                 )
             resolved_columns = [replacements.get(col, col) for col in value_columns]
-            keep_columns = [category_column, *resolved_columns]
+            keep_columns = list(dict.fromkeys([category_column, *resolved_columns]))
             working_df = working_df[keep_columns].copy()
             for col in resolved_columns:
                 working_df[col] = pd.to_numeric(working_df[col], errors="coerce")


### PR DESCRIPTION
### Motivation
- Prevent duplicate column selection errors when `excess_*` transformations add or replace value columns and cause the same column name to appear multiple times in the selection list.

### Description
- Deduplicate `keep_columns` before subsetting the DataFrame by changing `keep_columns = [category_column, *resolved_columns]` to `keep_columns = list(dict.fromkeys([category_column, *resolved_columns]))` in `src/gabriel/utils/plot_utils.py`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_698a50967684832e80943db645bc767e)