### PR TITLE
Fix error bar grouping for bar_plot

### DIFF
--- a/src/gabriel/utils/plot_utils.py
+++ b/src/gabriel/utils/plot_utils.py
@@ -1956,7 +1956,7 @@ def bar_plot(
             def _compute_error_from_string(kind: str) -> List[float]:
                 mode = (kind or "").strip().lower()
                 reference_column = aggregated.columns[0]
-                grouped_series = grouped[reference_column]
+                grouped_series = working_df.groupby(category_column, observed=True)[reference_column]
                 if mode == "std":
                     series = grouped_series.std(ddof=1)
                 elif mode == "sem":


### PR DESCRIPTION
### Motivation
- Calling `bar_plot` with string `error_bars` (e.g. `"ci95"`) could raise an `IndexError` when the grouped object had already been column-selected, because the code attempted to index into a `GroupBy` with an already-restricted selection. 

### Description
- Replaced `grouped[reference_column]` with a fresh grouping on `working_df` via `working_df.groupby(category_column, observed=True)[reference_column]` to avoid re-selecting columns from an already-selected `GroupBy` object. 
- Change is a single-line update in `src/gabriel/utils/plot_utils.py` inside the `bar_plot` function's `_compute_error_from_string` helper. 

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_698a601a66f8832ea7e6e0d285b81432)