### PR TITLE
Restore HTTPX client kwargs in `get_response` and adjust tests

### DIFF
--- a/src/gabriel/utils/openai_utils.py
+++ b/src/gabriel/utils/openai_utils.py
@@ -1819,14 +1819,11 @@ async def get_response(
         set_log_level(logging_level)
     _require_api_key()
     base_url = base_url or os.getenv("OPENAI_BASE_URL")
-    if httpx_max_connections or httpx_max_keepalive_connections:
-        client_async = _get_client(
-            base_url,
-            httpx_max_connections=httpx_max_connections,
-            httpx_max_keepalive_connections=httpx_max_keepalive_connections,
-        )
-    else:
-        client_async = _get_client(base_url)
+    client_async = _get_client(
+        base_url,
+        httpx_max_connections=httpx_max_connections,
+        httpx_max_keepalive_connections=httpx_max_keepalive_connections,
+    )
 
     try:
         poll_interval = float(background_poll_interval)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -275,7 +275,9 @@ def test_get_response_background_poll(monkeypatch):
             self.responses = FakeResponses()
 
     fake_client = FakeClient()
-    monkeypatch.setattr(openai_utils, "_get_client", lambda base_url=None: fake_client)
+    monkeypatch.setattr(
+        openai_utils, "_get_client", lambda base_url=None, **kwargs: fake_client
+    )
 
     async def _runner():
         return await openai_utils.get_response(
@@ -327,7 +329,9 @@ def test_get_response_polls_only_when_needed(monkeypatch):
 
     fake_responses = FakeResponses()
     fake_client = type("FakeClient", (), {"responses": fake_responses})()
-    monkeypatch.setattr(openai_utils, "_get_client", lambda base_url=None: fake_client)
+    monkeypatch.setattr(
+        openai_utils, "_get_client", lambda base_url=None, **kwargs: fake_client
+    )
 
     texts, duration, raw = asyncio.run(
         openai_utils.get_response(


### PR DESCRIPTION
### Motivation

- A recent change stopped forwarding `httpx_max_connections`/`httpx_max_keepalive_connections` to the shared client, introducing a regression that surfaced as early JSON parsing/timeouts during high-parallel runs. 
- The intent is to restore the previous behavior so callers (and tests) can inject HTTPX connection limits safely.

### Description

- Restore always-forwarded HTTPX connection limit arguments when constructing the async client in `get_response` by calling `_get_client(base_url, httpx_max_connections=..., httpx_max_keepalive_connections=...)`.
- Update two background-polling tests to make their `_get_client` stubs accept arbitrary keyword arguments by using `lambda base_url=None, **kwargs: fake_client` so the tests remain compatible with the restored call signature.

### Testing

- Ran `pytest -q`; initial run (before updating tests) produced 2 failures in `test_get_response_background_poll` and `test_get_response_polls_only_when_needed` due to the changed `_get_client` call signature. 
- After updating tests and restoring the forwarded kwargs, re-ran `pytest -q` and all tests passed: `177 passed, 6 skipped, 29 warnings`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_698a7a850424832ea70ec0e3e2ca01f0)