### PR TITLE
Adjust default HTTPX connection handling

### DIFF
--- a/src/gabriel/utils/openai_utils.py
+++ b/src/gabriel/utils/openai_utils.py
@@ -3096,9 +3096,9 @@ async def get_all_responses(
     scale back up.
 
     The shared HTTPX client can be tuned via ``httpx_max_connections`` and
-    ``httpx_max_keepalive_connections``.  When not supplied, the helper derives
-    a default limit from the requested ``n_parallels`` so that the connection
-    pool can accommodate the full worker ceiling.
+    ``httpx_max_keepalive_connections``. When omitted, the helper leaves the
+    OpenAI SDK defaults intact; pass explicit values if you want to override
+    the connection pool size.
 
     Connection errors (e.g., transient network drops, Wi‑Fi/VPN instability, or bandwidth limitations)
     are handled similarly: the helper tracks recent connection failures over
@@ -3430,10 +3430,11 @@ async def get_all_responses(
     status = StatusTracker()
     requested_n_parallels = max(1, n_parallels)
     user_requested_n_parallels = requested_n_parallels
-    if httpx_max_connections is None:
-        httpx_max_connections = int(math.ceil(requested_n_parallels * 1.5))
-    if httpx_max_keepalive_connections is None:
-        httpx_max_keepalive_connections = httpx_max_connections
+    if httpx_max_connections is not None or httpx_max_keepalive_connections is not None:
+        if httpx_max_connections is None:
+            httpx_max_connections = httpx_max_keepalive_connections
+        if httpx_max_keepalive_connections is None:
+            httpx_max_keepalive_connections = httpx_max_connections
     tokenizer = _get_tokenizer(model)
     # Backwards compatibility for identifiers
     if identifiers is None:


### PR DESCRIPTION
### Motivation
- Avoid forcibly deriving HTTPX pool sizes from `n_parallels` so the OpenAI SDK/httpx defaults are preserved by default and to reduce early-run instability when ramping concurrency (change made in `src/gabriel/utils/openai_utils.py`).

### Description
- Stop auto-setting `httpx_max_connections`/`httpx_max_keepalive_connections` from `n_parallels` and instead leave both as `None` unless the caller explicitly provides values, while still coalescing the two when one is specified.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_698a7f868688832e91da8210464b6e4f)