### PR TITLE
Improve JSON parse error logging

### DIFF
--- a/src/gabriel/utils/parsing.py
+++ b/src/gabriel/utils/parsing.py
@@ -131,13 +131,15 @@ def safe_json(txt: Any) -> Union[dict, list]:
         return {}
 
 
-def parse_json_with_status(txt: Any) -> Tuple[Optional[Union[dict, list]], bool]:
+def parse_json_with_status(
+    txt: Any,
+) -> Tuple[Optional[Union[dict, list]], bool, Optional[Exception]]:
     """Parse JSON and report success separately from the parsed value."""
 
     try:
-        return _parse_json(txt), True
-    except Exception:
-        return None, False
+        return _parse_json(txt), True, None
+    except Exception as exc:  # pragma: no cover - exercised via validation paths
+        return None, False, exc
 
 
 async def safest_json(


### PR DESCRIPTION
### Motivation
- Make it easier to diagnose intermittent JSON parsing failures (e.g. the early "JSON parsing failed" bursts seen during high-concurrency runs) by surfacing the underlying parse exception in logs and error records. 
- Provide richer diagnostics for JSON-mode validation so callers can see both a snippet of the invalid payload and the exact parsing error type/message. 

### Description
- Change `parse_json_with_status` in `src/gabriel/utils/parsing.py` to return an optional `Exception` alongside the parsed value and success flag via the signature `-> Tuple[Optional[Union[dict, list]], bool, Optional[Exception]]` so callers can access the underlying parse exception. 
- Extend `JSONParseError` in `src/gabriel/utils/openai_utils.py` to accept a `parse_error` field and store the original exception. 
- Update JSON-mode validation in `get_all_responses` to collect parse errors for invalid payloads and include the parse error details in the logged/emitted error text and `Error Log` entries so operators see `Cause: <ExceptionType>: <message>` plus the payload snippet. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_698a83b8a9c4832eb40f74045477926e)