### PR TITLE
Normalize checkpoint success flags and identifier handling to fix resume behavior

### DIFF
--- a/tests/test_reset_files.py
+++ b/tests/test_reset_files.py
@@ -1,4 +1,5 @@
 import asyncio
+import pandas as pd
 from gabriel.utils import openai_utils
 
 
@@ -22,3 +23,35 @@ def test_get_all_responses_reset_files(tmp_path):
         )
     )
     assert set(df["Identifier"]) == {"2"}
+
+
+def test_resume_treats_string_success_values_as_completed(tmp_path):
+    save_path = tmp_path / "out.csv"
+    pd.DataFrame(
+        {
+            "Identifier": ["1", "2", "3"],
+            "Response": ["[]", "[]", "[]"],
+            "Web Search Sources": ["[]", "[]", "[]"],
+            "Time Taken": [0.1, 0.1, 0.1],
+            "Input Tokens": [1, 1, 1],
+            "Reasoning Tokens": [0, 0, 0],
+            "Output Tokens": [1, 1, 1],
+            "Reasoning Effort": ["default", "default", "default"],
+            "Successful": ["True", "true", "1"],
+            "Error Log": ["[]", "[]", "[]"],
+            "Response IDs": ["[]", "[]", "[]"],
+            "Reasoning Summary": ["", "", ""],
+        }
+    ).to_csv(save_path, index=False)
+
+    df = asyncio.run(
+        openai_utils.get_all_responses(
+            prompts=["a", "b", "c"],
+            identifiers=["1", "2", "3"],
+            save_path=str(save_path),
+            use_dummy=True,
+            reset_files=False,
+        )
+    )
+
+    assert len(df) == 3


### PR DESCRIPTION
### Motivation
- Resuming long runs could fail to detect completed rows when the `Successful` column was stored as strings (e.g. "True", "true", "1"), causing already-done rows to be reprocessed.
- Identifier type mismatches (numeric vs string) also prevented correct deduplication and resume logic.
- Make resume/checkpoint detection robust to hand-edited or legacy CSVs so partially completed runs reliably continue from checkpoints.

### Description
- Normalize the `Successful` column when loading a saved CSV by coercing boolean-like values and matching common success strings (`"true"`, `"1"`, `"yes"`, `"completed"`, etc.) before building the `done` set; change located in `src/gabriel/utils/openai_utils.py`.
- Normalize identifier handling to string form when computing `done`, filtering `todo_pairs`, and during write-time deduplication so comparisons are type-consistent; updates in `src/gabriel/utils/openai_utils.py`.
- Ensure `written_identifiers` stores string identifiers and use `astype(str)` when checking `batch_df` to avoid reappends of already-saved rows; updates in `src/gabriel/utils/openai_utils.py`.
- Add a regression test `test_resume_treats_string_success_values_as_completed` to `tests/test_reset_files.py` that seeds a checkpoint CSV with string-valued `Successful` entries and verifies `reset_files=False` resumes without reprocessing those rows.

### Testing
- Ran `pytest -q tests/test_reset_files.py tests/test_openai_dummy.py` and both tests suites passed locally (`6 passed` for the two test files run).
- The new regression test confirms previously failing behavior (string success flags treated as incomplete) is resolved.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_698a9179da38832e9155274b141a53f2)