### PR TITLE
Add early n_attributes_per_run validation in task run methods#1

### DIFF
--- a/src/gabriel/tasks/classify.py
+++ b/src/gabriel/tasks/classify.py
@@ -182,6 +182,9 @@ class Classify:
             legacy_filename=f"{base_name}_attrs.json",
         )
 
+        if not isinstance(self.cfg.n_attributes_per_run, int) or self.cfg.n_attributes_per_run < 1:
+            raise ValueError("n_attributes_per_run must be an integer >= 1")
+
         label_items = list(self.cfg.labels.items())
         label_count = len(label_items)
         if label_count > self.cfg.n_attributes_per_run:

--- a/src/gabriel/tasks/extract.py
+++ b/src/gabriel/tasks/extract.py
@@ -146,6 +146,9 @@ class Extract:
             item_name="attributes",
             legacy_filename=f"{base_name}_attrs.json",
         )
+
+        if not isinstance(self.cfg.n_attributes_per_run, int) or self.cfg.n_attributes_per_run < 1:
+            raise ValueError("n_attributes_per_run must be an integer >= 1")
         values = df_proc[column_name].tolist()
         texts = [str(v) for v in values]
 

--- a/src/gabriel/tasks/rate.py
+++ b/src/gabriel/tasks/rate.py
@@ -139,6 +139,9 @@ class Rate:
             legacy_filename=f"{base_name}_attrs.json",
         )
 
+        if not isinstance(self.cfg.n_attributes_per_run, int) or self.cfg.n_attributes_per_run < 1:
+            raise ValueError("n_attributes_per_run must be an integer >= 1")
+
         attr_items = list(self.cfg.attributes.items())
         attr_count = len(attr_items)
         if attr_count > self.cfg.n_attributes_per_run:


### PR DESCRIPTION
### Motivation

- Ensure invalid `n_attributes_per_run` values fail early with a clear, user-facing error before any arithmetic or `range` usage that could raise obscure errors.

### Description

- Added an explicit check `if not isinstance(self.cfg.n_attributes_per_run, int) or self.cfg.n_attributes_per_run < 1:` in `Rate.run`, `Classify.run`, and `Extract.run` to validate `n_attributes_per_run`.
- Each method now raises `ValueError("n_attributes_per_run must be an integer >= 1")` when the validation fails.
- The validation is placed before batching calculations and `range(..., n_attributes_per_run)` usage so failures are deterministic and descriptive.
- Files changed: `src/gabriel/tasks/rate.py`, `src/gabriel/tasks/classify.py`, and `src/gabriel/tasks/extract.py`.

### Testing

- Ran `python -m compileall src/gabriel/tasks/rate.py src/gabriel/tasks/classify.py src/gabriel/tasks/extract.py` and compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699323c366ec83289f13bbc7a4017b70)